### PR TITLE
Update rubocop to v0.52.1 for XMPP plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.0] 2018-01-21
+### Changed
+- Bumped Rubocop to v0.52.1 in response to CVE-2017-8418 (@nicoleheejin)
+
 ## [1.0.1] - 2017-08-04
 ### Fixed
 - check-xmpp-login.rb do not rescue from SystemExit (@ushis)

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/handler-xmpp.rb
+++ b/bin/handler-xmpp.rb
@@ -4,9 +4,10 @@
 require 'sensu-handler'
 require 'xmpp4r/client'
 require 'xmpp4r/muc'
-include Jabber
 
 class XmppHandler < Sensu::Handler
+  include Jabber
+
   def event_name
     @event['client']['name'] + '/' + @event['check']['name']
   end

--- a/sensu-plugins-xmpp.gemspec
+++ b/sensu-plugins-xmpp.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-xmpp'
 
-Gem::Specification.new do |s| #rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for working with xmpp'

--- a/sensu-plugins-xmpp.gemspec
+++ b/sensu-plugins-xmpp.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-xmpp'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| #rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for working with xmpp'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-xmpp'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   s.summary                = 'Sensu plugins for working with xmpp'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsXmpp::Version::VER_STRING
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.52.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yeah! https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed
This is broken for me due to unrelated code, will look into later.

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
There's a CVE out for Rubocop, and this fixes that. sensu-plugins/community#77

#### Known Compatibility Issues
None that I'm aware of.